### PR TITLE
Shell lint

### DIFF
--- a/scripts/daily_maintenance.sh
+++ b/scripts/daily_maintenance.sh
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: 2025 Blackcat Informatics® Inc.
 # SPDX-License-Identifier: MIT
 
+# Orchestrates dumps, log capture, pgBadger reports, and retention pruning.
+# Intended to be called by manage.sh daily-maintenance.
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/scripts/daily_maintenance.sh
+++ b/scripts/daily_maintenance.sh
@@ -59,5 +59,5 @@ else
 fi
 
 echo "[daily] applying retention ${RETENTION_DAYS} days"
-find "${HOST_BACKUP_ROOT}" -mindepth 1 -maxdepth 1 -type d | sort | head -n -${RETENTION_DAYS} | xargs -r rm -rf
+find "${HOST_BACKUP_ROOT}" -mindepth 1 -maxdepth 1 -type d | sort | head -n -"${RETENTION_DAYS}" | xargs -r rm -rf
 echo "[daily] complete"

--- a/scripts/lib/backup.sh
+++ b/scripts/lib/backup.sh
@@ -3,6 +3,8 @@
 
 # shellcheck shell=bash
 
+# pgBackRest and logical backup helpers used by manage.sh.
+# cmd_dump writes a custom-format pg_dump archive compressed with gzip.
 cmd_dump() {
   ensure_env
   if [[ $# -lt 1 ]]; then
@@ -16,6 +18,7 @@ cmd_dump() {
   echo "Dump written to ${outfile}" >&2
 }
 
+# cmd_dump_sql produces a plain-text pg_dump suitable for review or editing.
 cmd_dump_sql() {
   ensure_env
   if [[ $# -lt 1 ]]; then
@@ -29,6 +32,7 @@ cmd_dump_sql() {
   echo "Plain SQL dump written to ${outfile}" >&2
 }
 
+# cmd_restore_dump recreates the database and restores a gzip-compressed custom dump.
 cmd_restore_dump() {
   ensure_env
   if [[ $# -ne 2 ]]; then
@@ -47,6 +51,7 @@ SQL
     bash -lc "gunzip -c '${infile}' | pg_restore --dbname='${db}' --username='${POSTGRES_SUPERUSER:-postgres}'"
 }
 
+# cmd_backup wraps pgBackRest backup with optional type selection (full/diff/incr).
 cmd_backup() {
   ensure_env
   local backup_type="auto"
@@ -69,6 +74,7 @@ cmd_backup() {
     "${cmd[@]}"
 }
 
+# cmd_stanza_create initializes the pgBackRest stanza inside the container.
 cmd_stanza_create() {
   ensure_env
   compose_exec env -u PGBACKREST_REPO_DIR PGHOST="${POSTGRES_HOST}" \
@@ -77,6 +83,7 @@ cmd_stanza_create() {
     pgbackrest --config="${PGBACKREST_CONF}" --stanza=main stanza-create
 }
 
+# cmd_restore_snapshot proxies pgBackRest restore with arbitrary arguments.
 cmd_restore_snapshot() {
   ensure_env
   compose_exec env -u PGBACKREST_REPO_DIR PGHOST="${POSTGRES_HOST}" \
@@ -85,6 +92,7 @@ cmd_restore_snapshot() {
     pgbackrest --config="${PGBACKREST_CONF}" --stanza=main --log-level-console=info restore "$@"
 }
 
+# cmd_provision_qa captures a diff backup and restores a specific database for QA.
 cmd_provision_qa() {
   ensure_env
   if [[ $# -ne 1 ]]; then

--- a/scripts/lib/backup.sh
+++ b/scripts/lib/backup.sh
@@ -49,18 +49,18 @@ SQL
 
 cmd_backup() {
   ensure_env
-  local type=auto
+  local backup_type="auto"
   if [[ $# -ge 1 ]]; then
     case $1 in
-      --type=full) type=full ;;
-      --type=diff) type=diff ;;
-      --type=incr) type=incr ;;
+      --type=full) backup_type="full" ;;
+      --type=diff) backup_type="diff" ;;
+      --type=incr) backup_type="incr" ;;
       *) echo "Unknown backup type '$1'" >&2; exit 1 ;;
     esac
   fi
   local cmd=(pgbackrest --config="${PGBACKREST_CONF}" --stanza=main --log-level-console=info)
-  if [[ ${type} != auto ]]; then
-    cmd+=("--type=${type}")
+  if [[ ${backup_type} != "auto" ]]; then
+    cmd+=("--type=${backup_type}")
   fi
   cmd+=(backup)
   compose_exec env -u PGBACKREST_REPO_DIR PGHOST="${POSTGRES_HOST}" \

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2025 Blackcat Informatics® Inc.
 # SPDX-License-Identifier: MIT
 
+# Common helpers shared by manage.sh and supporting scripts.
 set -euo pipefail
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
@@ -22,18 +23,22 @@ else
   echo "[core_data] WARNING: ${ENV_FILE} not found; using defaults where possible." >&2
 fi
 
+# compose runs docker compose with the arguments provided.
 compose() {
   ${COMPOSE_BIN} "$@"
 }
 
+# compose_exec runs docker compose exec with the postgres user (no TTY).
 compose_exec() {
   compose exec -T --user "${POSTGRES_EXEC_USER}" "${PG_CONTAINER}" "$@"
 }
 
+# compose_run runs docker compose run for ephemeral helper containers.
 compose_run() {
   compose run --rm "$@"
 }
 
+# ensure_compose exits early if the docker CLI is not available.
 ensure_compose() {
   if ! command -v docker >/dev/null 2>&1; then
     echo "[core_data] docker CLI not available." >&2
@@ -41,6 +46,7 @@ ensure_compose() {
   fi
 }
 
+# ensure_env makes sure a populated .env file exists before continuing.
 ensure_env() {
   if [[ ! -f "${ENV_FILE}" ]]; then
     echo "[core_data] Missing .env file. Copy .env.example and customize before running commands." >&2

--- a/scripts/lib/db.sh
+++ b/scripts/lib/db.sh
@@ -3,6 +3,8 @@
 
 # shellcheck shell=bash
 
+# Database role and schema helpers used by manage.sh.
+# cmd_create_user creates a role with LOGIN privilege if it does not yet exist.
 cmd_create_user() {
   ensure_env
   if [[ $# -ne 2 ]]; then
@@ -24,6 +26,7 @@ END
 SQL
 }
 
+# cmd_drop_user removes a role when present, ignoring missing roles.
 cmd_drop_user() {
   ensure_env
   if [[ $# -ne 1 ]]; then
@@ -44,6 +47,7 @@ END
 SQL
 }
 
+# cmd_create_db ensures the owner exists, creates the database, and bootstraps extensions.
 cmd_create_db() {
   ensure_env
   if [[ $# -ne 2 ]]; then
@@ -74,6 +78,7 @@ SQL
   schedule_pg_squeeze_job "${db}"
 }
 
+# cmd_drop_db unschedules cron jobs and drops the database after terminating sessions.
 cmd_drop_db() {
   ensure_env
   if [[ $# -ne 1 ]]; then

--- a/scripts/lib/maintenance.sh
+++ b/scripts/lib/maintenance.sh
@@ -3,6 +3,8 @@
 
 # shellcheck shell=bash
 
+# pgBadger and daily maintenance helpers used by manage.sh.
+# cmd_pgbadger_report generates a pgBadger HTML report from recent CSV logs.
 cmd_pgbadger_report() {
   ensure_env
   local since=""
@@ -42,6 +44,7 @@ cmd_pgbadger_report() {
   echo "pgBadger report written to ${output}" >&2
 }
 
+# cmd_daily_maintenance orchestrates daily dumps, log copy, pgBadger, and retention.
 cmd_daily_maintenance() {
   ensure_env
   local backup_root=${DAILY_BACKUP_ROOT:-./backups/daily}

--- a/scripts/lib/upgrade.sh
+++ b/scripts/lib/upgrade.sh
@@ -123,7 +123,6 @@ USAGE
     exit 0
   fi
 
-  local old_version=${PG_VERSION}
   local data_dir
   data_dir=$(realpath -m "${PG_DATA_DIR}")
 

--- a/scripts/lib/upgrade.sh
+++ b/scripts/lib/upgrade.sh
@@ -3,6 +3,8 @@
 
 # shellcheck shell=bash
 
+# Major version upgrade workflow helpers for manage.sh.
+# _update_env_var rewrites a key=value entry inside the active .env file.
 _update_env_var() {
   local key=$1
   local value=$2
@@ -30,6 +32,7 @@ path.write_text("\n".join(lines) + "\n")
 PY
 }
 
+# _ensure_base_image pulls the postgres base image for the target version.
 _ensure_base_image() {
   local version=$1
   local image="postgres:${version}-bookworm"
@@ -45,6 +48,7 @@ _ensure_base_image() {
   exit 1
 }
 
+# _select_helper_image chooses a pgautoupgrade image compatible with the upgrade target.
 _select_helper_image() {
   local version=$1
   local candidates=(
@@ -72,6 +76,7 @@ _select_helper_image() {
   echo "${image}"
 }
 
+# _wait_for_postgres polls pg_isready until the upgraded server is healthy.
 _wait_for_postgres() {
   local retries=${1:-30}
   local delay=${2:-5}
@@ -85,6 +90,7 @@ _wait_for_postgres() {
   return 1
 }
 
+# cmd_upgrade coordinates backups, pgautoupgrade, image rebuild, and verification.
 cmd_upgrade() {
   ensure_env
   local new_version=""

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -107,8 +107,6 @@ def manage_env(tmp_path_factory):
             backups_link.unlink()
         if had_existing_backups and original_backups.exists():
             original_backups.rename(backups_link)
-        else:
-            backups_link.mkdir(exist_ok=True)
         env_file.unlink(missing_ok=True)
         if had_env and backup_env_bytes is not None:
             repo_env_path.write_bytes(backup_env_bytes)


### PR DESCRIPTION
This pull request adds comprehensive documentation comments to all helper scripts and functions used by `manage.sh`, improves code clarity, and fixes a minor bug in retention pruning logic. The main changes are grouped below:

**Documentation and Code Clarity Improvements:**

* Added detailed comments describing the purpose and usage of each script and helper function in `scripts/daily_maintenance.sh`, `scripts/lib/backup.sh`, `scripts/lib/common.sh`, `scripts/lib/db.sh`, `scripts/lib/maintenance.sh`, and `scripts/lib/upgrade.sh`. This makes it easier to understand and maintain the codebase. [[1]](diffhunk://#diff-df404f5402d633b5e4a07004792029c88e8ec5c05b6a187a7e93e4acbcf2e7b0R5-R6) [[2]](diffhunk://#diff-906a6954c9e5712d666ea40f02f3c346525853f96cf956f9141e3cfb6baf7095R6-R7) [[3]](diffhunk://#diff-50b3ca9172ca65b47d8842ac4aad6c8ba1e77c2ccf7501f4ec1c663c91cdb9e0R5) [[4]](diffhunk://#diff-5d1cf49fcf27dcf2d80e2b71c557db4aa0ea70e6f4ec7a952faca7bcba90c116R6-R7) [[5]](diffhunk://#diff-f2664ed6d5d1fb32ad78b48c88b95d5e25866032bca549d85b2c76bc874be7a5R6-R7) [[6]](diffhunk://#diff-2c3362ed92a5dd7e359ac6b9d6be2264b3732c9fd6a6860246191345831bb163R6-R7)

**Bug Fixes and Logic Corrections:**

* Fixed a bug in the retention pruning command in `scripts/daily_maintenance.sh` by quoting the `${RETENTION_DAYS}` variable, ensuring correct behavior when deleting old backups.

**Refactoring and Naming Consistency:**

* Improved variable naming in `cmd_backup` in `scripts/lib/backup.sh` for clarity and consistency (renamed `type` to `backup_type`).

**Minor Code Cleanups:**

* Removed unnecessary directory creation in test cleanup logic in `tests/test_manage.py`, streamlining test teardown.

These changes collectively enhance maintainability, reliability, and developer onboarding for the backup and maintenance scripts.