### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/paudley/core_data/security/code-scanning/1](https://github.com/paudley/core_data/security/code-scanning/1)

To address the issue, we should explicitly set the least required permissions at the workflow level by introducing a `permissions` block at the top level of the workflow YAML. For the steps shown, the minimal permission necessary is `contents: read`, which lets the workflow check out code but does not allow writing to the repository, modifying issues, or other elevated actions. The edit should be made after the `name:` key and before the `on:` block (i.e., after line 4). No changes to the jobs or steps are required, and functionality will remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
