### PR TITLE
add a service-urls command, change the docker volumes to local bind m…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,7 +110,7 @@ PGBOUNCER_PORT=6432
 # Host port that exposes PgBouncer; override to avoid collisions without
 # changing the internal listener.
 PGBOUNCER_HOST_PORT=6432
-PGBOUNCER_POOL_MODE=transaction
+PGBOUNCER_POOL_MODE=session
 PGBOUNCER_MAX_CLIENT_CONN=200
 PGBOUNCER_DEFAULT_POOL_SIZE=20
 PGBOUNCER_RESERVE_POOL_SIZE=5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,9 @@ services:
         "chown -R ${POSTGRES_UID:-999}:${POSTGRES_GID:-999} $${PGDATA_MOUNT} $${PGWAL_MOUNT} $${PGBACKREST_MOUNT}"
       ]
     volumes:
-      - pgdata:${POSTGRES_DATA_MOUNT_PATH:-/var/lib/postgresql/data}
-      - pgwal:${POSTGRES_WAL_MOUNT_PATH:-/var/lib/postgresql/wal}
-      - pgbackrest:${POSTGRES_BACKREST_MOUNT_PATH:-/var/lib/pgbackrest}
+      - ./data/postgres_data:${POSTGRES_DATA_MOUNT_PATH:-/var/lib/postgresql/data}
+      - ./data/postgres_wal:${POSTGRES_WAL_MOUNT_PATH:-/var/lib/postgresql/wal}
+      - ./data/pgbackrest:${POSTGRES_BACKREST_MOUNT_PATH:-/var/lib/pgbackrest}
     networks:
       - core_data
     logging: *logging_defaults
@@ -86,9 +86,9 @@ services:
       POSTGRES_SSL_SELF_SIGNED_DAYS: ${POSTGRES_SSL_SELF_SIGNED_DAYS}
       POSTGRES_INITDB_WALDIR: /var/lib/postgresql/wal
     volumes:
-      - pgdata:${POSTGRES_DATA_MOUNT_PATH:-/var/lib/postgresql/data}
-      - pgwal:${POSTGRES_WAL_MOUNT_PATH:-/var/lib/postgresql/wal}
-      - pgbackrest:${POSTGRES_BACKREST_MOUNT_PATH:-/var/lib/pgbackrest}
+      - ./data/postgres_data:${POSTGRES_DATA_MOUNT_PATH:-/var/lib/postgresql/data}
+      - ./data/postgres_wal:${POSTGRES_WAL_MOUNT_PATH:-/var/lib/postgresql/wal}
+      - ./data/pgbackrest:${POSTGRES_BACKREST_MOUNT_PATH:-/var/lib/pgbackrest}
       - ./backups:/backups
       - ./postgres/conf:/opt/core_data/conf:ro
       - ./postgres/initdb:/docker-entrypoint-initdb.d:ro
@@ -192,7 +192,7 @@ services:
       VALKEY_PASSWORD_FILE: /run/secrets/valkey_password
     command: ["/opt/core_data/valkey-entrypoint.sh"]
     volumes:
-      - valkey_data:/data
+      - ./data/valkey_data:/data
       - ./valkey/entrypoint.sh:/opt/core_data/valkey-entrypoint.sh:ro
       - ./secrets/valkey_password:/run/secrets/valkey_password:ro
     networks:
@@ -293,9 +293,3 @@ networks:
     ipam:
       config:
         - subnet: ${DOCKER_NETWORK_SUBNET}
-
-volumes:
-  pgdata:
-  pgwal:
-  pgbackrest:
-  valkey_data:

--- a/scripts/lib/extensions_list.sh
+++ b/scripts/lib/extensions_list.sh
@@ -12,6 +12,7 @@ CORE_EXTENSION_LIST=(
   dblink
   hstore
   fuzzystrmatch
+  bloom
   pg_buffercache
   pg_cron
   pg_partman


### PR DESCRIPTION
This pull request introduces several improvements to the local development environment setup and management scripts. The main themes are simplifying Docker volume management, enhancing service connection visibility, and minor configuration and extension updates.

**Docker Compose and Volume Management:**

* Changed Docker Compose volume definitions for `postgres` and `valkey` services to use local `./data` directories instead of named volumes, making data storage more transparent and easier to manage. (`docker-compose.yml`) [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L35-R37) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L89-R91) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L195-R195)
* Removed the named volume definitions from the bottom of `docker-compose.yml`, as they are no longer needed. (`docker-compose.yml`)

**Service Connection URLs:**

* Added a new `service-urls` command to `scripts/manage.sh` that prints connection URLs for local services (Postgres, PgBouncer, Valkey, Memcached, and PgHero), using the detected external host IP and loaded secrets. This helps users quickly find connection details for development and debugging. (`scripts/manage.sh`) [[1]](diffhunk://#diff-82bff7ac0bfac811df6060c2769b18b55609a3c8876a371e13e21f697541820dR178) [[2]](diffhunk://#diff-82bff7ac0bfac811df6060c2769b18b55609a3c8876a371e13e21f697541820dR232-R315) [[3]](diffhunk://#diff-82bff7ac0bfac811df6060c2769b18b55609a3c8876a371e13e21f697541820dR1099-R1101)

**Configuration and Extensions:**

* Changed the default PgBouncer pool mode from `transaction` to `session` in `.env.example`, which may affect connection pooling behavior. (`.env.example`)
* Added the `bloom` extension to the core extension list for Postgres, making it available in the database by default. (`scripts/lib/extensions_list.sh`)