### PR TITLE
allow AGE access to owners by default

### DIFF
--- a/scripts/lib/db.sh
+++ b/scripts/lib/db.sh
@@ -47,7 +47,7 @@ END
 SQL
 }
 
-# grant_db_owner_privileges ensures the owner can manage objects in the public schema.
+# grant_db_owner_privileges ensures the owner can manage objects in public and ag_catalog schemas.
 grant_db_owner_privileges() {
   local db=$1
   local owner=$2
@@ -59,6 +59,9 @@ GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO "${owner}";
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO "${owner}";
 ALTER DEFAULT PRIVILEGES FOR ROLE "${POSTGRES_SUPERUSER:-postgres}" IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO "${owner}";
 ALTER DEFAULT PRIVILEGES FOR ROLE "${POSTGRES_SUPERUSER:-postgres}" IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO "${owner}";
+GRANT USAGE ON SCHEMA ag_catalog TO "${owner}";
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ag_catalog TO "${owner}";
+ALTER DEFAULT PRIVILEGES FOR ROLE "${POSTGRES_SUPERUSER:-postgres}" IN SCHEMA ag_catalog GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "${owner}";
 SQL
 }
 


### PR DESCRIPTION
This pull request updates the database privilege management script to ensure that database owners have the necessary permissions not only in the `public` schema but also in the `ag_catalog` schema. The main focus is on extending privilege grants to cover additional schemas relevant for certain database extensions.

**Privilege management enhancements:**

* The `grant_db_owner_privileges` function in `scripts/lib/db.sh` now ensures owners can manage objects in both `public` and `ag_catalog` schemas, rather than just `public`.
* Added statements to grant usage and data manipulation privileges (`SELECT`, `INSERT`, `UPDATE`, `DELETE`) on all tables in the `ag_catalog` schema to the database owner.
* Added default privilege grants for future tables in the `ag_catalog` schema, ensuring the owner retains necessary permissions on tables created after initial setup.