### PR TITLE
tweak permission for release workflow to make SBOM

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -11,7 +11,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}/postgres
 
 permissions:
-  contents: read
+  contents: write
   packages: write
   id-token: write
   attestations: write


### PR DESCRIPTION
This pull request updates the permissions in the GitHub Actions workflow for publishing Docker images. The most important change is that the `contents` permission has been elevated from `read` to `write`, which allows the workflow to perform write operations on repository contents.

Permissions update:

* [`.github/workflows/publish-docker.yml`](diffhunk://#diff-9136d7ee194d90376becf626f92179e6d99617d858ce125f6f73ca09fa410840L14-R14): Changed `contents` permission from `read` to `write` to enable write access to repository contents during the workflow.