### PR TITLE
remove the need to issue LOAD age commands to use cypher

### DIFF
--- a/postgres/conf/postgresql.conf.tpl
+++ b/postgres/conf/postgresql.conf.tpl
@@ -10,7 +10,7 @@ shared_buffers = ${PG_SHARED_BUFFERS}
 work_mem = ${PG_WORK_MEM}
 maintenance_work_mem = ${PG_MAINTENANCE_WORK_MEM}
 effective_cache_size = ${PG_EFFECTIVE_CACHE_SIZE}
-shared_preload_libraries = 'pgaudit,pg_stat_statements,pg_cron,pg_squeeze,auto_explain,pg_buffercache,pg_partman_bgw'
+shared_preload_libraries = 'age,pgaudit,pg_stat_statements,pg_cron,pg_squeeze,auto_explain,pg_buffercache,pg_partman_bgw'
 wal_level = logical
 archive_mode = on
 archive_command = 'pgbackrest --config=/var/lib/postgresql/data/pgbackrest.conf --stanza=main archive-push %p'

--- a/scripts/lib/extensions.sh
+++ b/scripts/lib/extensions.sh
@@ -23,8 +23,6 @@ SELECT embedding <-> '[1,2,4]'::vector AS distance FROM core_data_vector_demo OR
 -- PostGIS smoke
 SELECT ST_AsText(ST_Buffer(ST_GeomFromText('POINT(0 0)'), 1.0));
 
--- Apache AGE smoke
-LOAD 'age';
 SET search_path = ag_catalog, "$user", public;
 SELECT create_graph('core_data_smoke_graph')
   WHERE NOT EXISTS (SELECT 1 FROM ag_catalog.ag_graph WHERE name = 'core_data_smoke_graph');

--- a/scripts/test_data/test_dataset.psql
+++ b/scripts/test_data/test_dataset.psql
@@ -354,8 +354,6 @@ SELECT uuid_generate_v5(uuid_ns_url(), slug || ':api'), place_id
 FROM places
 ON CONFLICT (token) DO NOTHING;
 
--- Build a lightweight Apache AGE graph that mirrors the connectivity from route_edges.
-LOAD 'age';
 SET search_path = ag_catalog, "$user", public;
 
 SELECT drop_graph('testkit_graph', true)

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -1501,7 +1501,7 @@ def test_test_dataset_bootstrap(manage_env):
             "-t",
             "-A",
             "-c",
-            "LOAD 'age'; SET search_path = ag_catalog, \"$user\", public; "
+            "SET search_path = ag_catalog, \"$user\", public; "
             "SELECT source::text, target::text FROM cypher('testkit_graph', $$ MATCH (a:Place)-[:ROUTE]->(b:Place) RETURN a.slug AS source, b.slug AS target $$) "
             "AS (source agtype, target agtype) ORDER BY source::text, target::text;",
         )


### PR DESCRIPTION
This pull request primarily updates the PostgreSQL configuration and related scripts to improve integration with the Apache AGE extension. The most significant change is enabling AGE by default in the PostgreSQL server configuration, while redundant explicit `LOAD 'age'` statements are removed from various scripts and tests to streamline extension usage.

**PostgreSQL configuration update:**

* Enabled the Apache AGE extension by adding it to the `shared_preload_libraries` list in `postgres/conf/postgresql.conf.tpl`, ensuring AGE is loaded automatically with the database server.

**Script and test cleanup:**

* Removed explicit `LOAD 'age'` statements from `scripts/lib/extensions.sh` and `scripts/test_data/test_dataset.psql` since AGE is now preloaded, simplifying extension setup in utility scripts. [[1]](diffhunk://#diff-e839177488471ad322b42b36f49306f1887a4050d3f9e1f2ca6d4ca26ea4966aL26-L27) [[2]](diffhunk://#diff-5770bd25c72832b439e8c16c04f290801123d4ecf240d8e28562d0fa69412780L357-L358)
* Updated the test setup in `tests/test_manage.py` to remove the redundant `LOAD 'age'` command, relying on the preloaded extension for graph queries.