### PR TITLE
harden is_ready check

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -99,4 +99,4 @@ VOLUME ["/var/lib/postgresql/data", "/var/lib/pgbackrest", "/home/postgres"]
 USER ${CORE_USERNAME}
 
 HEALTHCHECK --start-period=30s --interval=10s --timeout=5s --retries=5 \
-    CMD pg_isready -U "$${POSTGRES_USER:-postgres}" || exit 1
+    CMD ["/opt/core_data/scripts/healthcheck.sh"]


### PR DESCRIPTION
This pull request updates the health check mechanism in the `postgres/Dockerfile` to use a custom script instead of the default `pg_isready` command. This change allows for more flexible and comprehensive health checks tailored to our deployment needs.

Health check update:

* Changed the `HEALTHCHECK` directive to use the `/opt/core_data/scripts/healthcheck.sh` script instead of the standard `pg_isready` command, enabling custom health check logic.