### PR TITLE
tz fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Default timezone now falls back to UTC when `TZ` is unset, preventing PostgreSQL from rendering `timezone = ''` and failing to start. (#31)
+
 ## [17.2-v1.0.0] - TBD
 
 ### Added

--- a/postgres/initdb/00-render-config.sh
+++ b/postgres/initdb/00-render-config.sh
@@ -44,6 +44,7 @@ apply_network_allow_entries() {
 	fi
 }
 
+: "${TZ:=UTC}"
 : "${POSTGRES_LISTEN_ADDRESSES:=0.0.0.0}"
 : "${POSTGRES_MAX_CONNECTIONS:=200}"
 : "${PG_SHARED_BUFFERS:=1GB}"
@@ -65,6 +66,7 @@ apply_network_allow_entries() {
 : "${POSTGRES_SSL_SELF_SIGNED_DAYS:=730}"
 
 export \
+	TZ \
 	POSTGRES_LISTEN_ADDRESSES \
 	POSTGRES_MAX_CONNECTIONS \
 	PG_SHARED_BUFFERS \


### PR DESCRIPTION
This pull request addresses an important bug related to timezone configuration for PostgreSQL initialization. The main change ensures that the system defaults to UTC if the `TZ` environment variable is unset, preventing database startup failures due to invalid timezone settings.

Bug fix for timezone handling:

* Added a fallback to UTC for the `TZ` environment variable in `postgres/initdb/00-render-config.sh`, preventing PostgreSQL from failing to start when `TZ` is unset.
* Exported the `TZ` variable in the environment setup to ensure consistent timezone configuration during initialization.

Documentation update:

* Documented the bug fix in the `CHANGELOG.md` under the "Fixed" section, describing the fallback behavior and its impact on PostgreSQL startup reliability.

Closes #31 