### PR TITLE
fix cosign

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           image_ref="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}"
           cosign verify \
-            --certificate-identity-regexp "^https://github.com/${{ github.repository }}/actions/runs/[0-9]+$" \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/publish-docker.yml@${{ github.ref }}" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             "${image_ref}"
 
@@ -166,7 +166,7 @@ jobs:
             **Verify signature (cosign):**
             ```bash
             cosign verify \
-              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/actions/runs/[0-9]+$" \
+              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/publish-docker.yml@${{ github.ref }}" \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
               oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}
             ```

--- a/CI_USAGE.md
+++ b/CI_USAGE.md
@@ -45,7 +45,7 @@ This repository ships helpers and workflows tuned for CI pipelines that rely on 
 - Images are signed keylessly with cosign during publish. Verify using the Actions OIDC issuer:
   ```bash
   cosign verify \
-    --certificate-identity-regexp '^https://github.com/paudley/core_data/actions/runs/[0-9]+$' \
+    --certificate-identity "https://github.com/paudley/core_data/.github/workflows/publish-docker.yml@refs/tags/<tag>" \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
     ghcr.io/paudley/core_data/postgres@<digest>
   ```


### PR DESCRIPTION
This pull request updates the Docker image signature verification process to use a more precise certificate identity in both workflow and documentation files. The main change replaces the previous use of a regular expression for certificate identity matching with an explicit certificate identity string referencing the workflow file and git ref. This improves clarity and security when verifying published images.

**Docker image signature verification updates:**

* [`.github/workflows/publish-docker.yml`](diffhunk://#diff-9136d7ee194d90376becf626f92179e6d99617d858ce125f6f73ca09fa410840L121-R121): Changed the `cosign verify` command to use `--certificate-identity` with the workflow file and git ref, replacing the previous regular expression approach.
* [`.github/workflows/publish-docker.yml`](diffhunk://#diff-9136d7ee194d90376becf626f92179e6d99617d858ce125f6f73ca09fa410840L169-R169): Updated the documentation block for verifying signatures to reflect the new `--certificate-identity` usage.
* [`CI_USAGE.md`](diffhunk://#diff-4604d17863445fa70bac07bf95851ed23dff74295b00864d76de825aecc0414aL48-R48): Updated the example for verifying published images to use the explicit certificate identity string, making instructions clearer and more accurate.