### PR TITLE
All the tokens

### DIFF
--- a/CI_USAGE.md
+++ b/CI_USAGE.md
@@ -42,11 +42,21 @@ This repository ships helpers and workflows tuned for CI pipelines that rely on 
   ```bash
   gh attestation verify oci://ghcr.io/paudley/core_data/postgres:<tag> --repo paudley/core_data
   ```
+<<<<<<< HEAD
 - To verify every image referenced by your `.env` (with detailed output), run:
   ```bash
   ./scripts/manage.sh attestation-verify --env-file ci.env.example
   ```
 - Only GHCR images owned by `${CORE_DATA_ATTESTATION_REPO}` are enforced. Third-party dependencies (e.g., `debian:bookworm-slim` for probes) are logged and skipped because GitHub attestations are unavailable for them.
+||||||| 6c87ec2
+=======
+- To verify every image referenced by your `.env` (with detailed output), run:
+  ```bash
+  ./scripts/manage.sh attestation-verify --env-file ci.env.example
+  ```
+- Only GHCR images owned by `${CORE_DATA_ATTESTATION_REPO}` are enforced. Third-party dependencies (e.g., `debian:bookworm-slim` for probes) are logged and skipped because GitHub attestations are unavailable for them.
+- If a runner-scoped `GH_TOKEN`/`GITHUB_TOKEN` lacks access to `paudley/core_data`, the helper automatically retries without credentials once it sees “token was denied access,” so public attestation checks still pass.
+>>>>>>> pretty_attestations
 - Images are signed keylessly with cosign during publish. Verify using the Actions OIDC issuer:
   ```bash
   cosign verify \

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ gh attestation verify oci://ghcr.io/paudley/core-data-postgres:17.2-v1.0.0 \
 ./scripts/manage.sh attestation-verify --env-file ci.env.example
 ```
 
+GitHub-hosted runners often inject job-scoped `GITHUB_TOKEN`/`GH_TOKEN` values that cannot read attestations from other repositories; the helper automatically retries anonymously when GitHub reports “token was denied access,” so no extra flags are required.
+
 Expected verification output:
 
 ```

--- a/scripts/lib/ci.sh
+++ b/scripts/lib/ci.sh
@@ -81,6 +81,7 @@ ci_verify_attestation_for_image() {
 		ci_log "gh CLI missing; skipping attestation check for ${image_ref}"
 		return 0
 	fi
+<<<<<<< HEAD
 	local tmp_json
 	local tmp_err
 	local parse_err="/dev/null"
@@ -99,8 +100,132 @@ ci_verify_attestation_for_image() {
 			return 1
 		fi
 		ci_log "warning: attestation verification failed for ${image_ref}${err_msg:+: ${err_msg}}; continuing because enforcement disabled."
+||||||| 6c87ec2
+	if gh attestation verify --repo "${repo}" --subject "${image_ref}" >/dev/null 2>&1; then
+		ci_log "attestation verified for ${image_ref}"
+=======
+	local tmp_json
+	local tmp_err
+	local parse_err="/dev/null"
+	tmp_json=$(mktemp)
+	tmp_err=$(mktemp)
+	parse_err=$(mktemp)
+	local err_msg=""
+	local attempt=1
+	while :; do
+		if [[ "${attempt}" -eq 2 ]]; then
+			GH_TOKEN= GITHUB_TOKEN= gh attestation verify "${subject}" --repo "${repo}" --format json >"${tmp_json}" 2>"${tmp_err}"
+		else
+			gh attestation verify "${subject}" --repo "${repo}" --format json >"${tmp_json}" 2>"${tmp_err}"
+		fi
+		if [[ $? -eq 0 ]]; then
+			break
+		fi
+		err_msg=$(<"${tmp_err}")
+		if [[ "${attempt}" -eq 1 && -n "${err_msg}" && "${err_msg}" == *"token was denied access"* && ( -n "${GH_TOKEN:-}" || -n "${GITHUB_TOKEN:-}" ) ]]; then
+			ci_log "gh token denied access for ${image_ref}; retrying without GH_TOKEN/GITHUB_TOKEN."
+			attempt=$((attempt + 1))
+			: >"${tmp_err}"
+			continue
+		fi
+		rm -f "${tmp_json}" "${tmp_err}" "${parse_err}"
+		if [[ "${enforce}" == "1" ]]; then
+			echo "[ci] attestation verification failed for ${image_ref}" >&2
+			if [[ -n "${err_msg}" ]]; then
+				echo "${err_msg}" >&2
+			fi
+			return 1
+		fi
+		ci_log "warning: attestation verification failed for ${image_ref}${err_msg:+: ${err_msg}}; continuing because enforcement disabled."
+		return 0
+	done
+	rm -f "${tmp_err}"
+	local parsed
+	if ! parsed=$(
+		python3 - "${expected_subject}" "${tmp_json}" <<'PY'
+import json
+import sys
+
+if len(sys.argv) != 3:
+    print("internal usage error: expected subject and json path", file=sys.stderr)
+    sys.exit(1)
+
+expected = sys.argv[1]
+json_path = sys.argv[2]
+
+with open(json_path, "r", encoding="utf-8") as fh:
+    payload = json.load(fh)
+
+match_entry = None
+match_subject = None
+for entry in payload:
+    result = entry.get("verificationResult", {})
+    statement = result.get("statement", {})
+    for subject in statement.get("subject") or []:
+        if subject.get("name") == expected:
+            match_entry = entry
+            match_subject = subject
+            break
+    if match_entry is not None:
+        break
+
+if match_entry is None or match_subject is None:
+    print(f"Subject {expected} not present in attestation payload.", file=sys.stderr)
+    sys.exit(1)
+
+statement = match_entry["verificationResult"]["statement"]
+predicate_type = statement.get("predicateType")
+if predicate_type != "https://slsa.dev/provenance/v1":
+    print(f"Unexpected predicate type: {predicate_type}", file=sys.stderr)
+    sys.exit(1)
+
+subject_digest = match_subject.get("digest", {}).get("sha256")
+if not subject_digest:
+    print("Attestation missing subject digest.", file=sys.stderr)
+    sys.exit(1)
+
+predicate = statement.get("predicate", {})
+build_def = predicate.get("buildDefinition", {})
+external = build_def.get("externalParameters", {}) if build_def else {}
+workflow = external.get("workflow", {}) if isinstance(external, dict) else {}
+run_details = predicate.get("runDetails", {})
+builder_id = (run_details.get("builder", {}) or {}).get("id", "")
+invocation = (run_details.get("metadata", {}) or {}).get("invocationId", "")
+
+workflow_repo = workflow.get("repository", "")
+workflow_path = workflow.get("path", "")
+workflow_ref = workflow.get("ref", "")
+
+print(f"subject_name={match_subject.get('name', '')}")
+print(f"subject_digest=sha256:{subject_digest}")
+print(f"predicate_type={predicate_type}")
+if builder_id:
+    print(f"builder_id={builder_id}")
+if invocation:
+    print(f"invocation={invocation}")
+if workflow_repo:
+    print(f"workflow_repo={workflow_repo}")
+if workflow_path:
+    print(f"workflow_path={workflow_path}")
+if workflow_ref:
+    print(f"workflow_ref={workflow_ref}")
+PY
+	) 2>"${parse_err}"; then
+		local py_err_msg
+		py_err_msg=$(<"${parse_err}")
+		rm -f "${tmp_json}" "${parse_err}"
+		if [[ "${enforce}" == "1" ]]; then
+			echo "[ci] attestation verification failed for ${image_ref}" >&2
+			if [[ -n "${py_err_msg}" ]]; then
+				echo "${py_err_msg}" >&2
+			fi
+			return 1
+		fi
+		ci_log "warning: attestation verification failed for ${image_ref}${py_err_msg:+: ${py_err_msg}}; continuing because enforcement disabled."
+>>>>>>> pretty_attestations
 		return 0
 	fi
+<<<<<<< HEAD
 	rm -f "${tmp_err}"
 	local parsed
 	if ! parsed=$(
@@ -251,6 +376,77 @@ PY
 	fi
 	if [[ -n "${invocation}" ]]; then
 		ci_log "  run        : ${invocation}"
+||||||| 6c87ec2
+	if [[ "${enforce}" == "1" ]]; then
+		echo "[ci] attestation verification failed for ${image_ref}" >&2
+		return 1
+=======
+	rm -f "${parse_err}"
+	rm -f "${tmp_json}"
+	local subject_name=""
+	local subject_digest=""
+	local predicate_type=""
+	local builder_id=""
+	local invocation=""
+	local workflow_repo=""
+	local workflow_path=""
+	local workflow_ref=""
+	while IFS= read -r line; do
+		local key=${line%%=*}
+		local value=${line#"${key}="}
+		case "${key}" in
+		subject_name)
+			subject_name=${value}
+			;;
+		subject_digest)
+			subject_digest=${value}
+			;;
+		predicate_type)
+			predicate_type=${value}
+			;;
+		builder_id)
+			builder_id=${value}
+			;;
+		invocation)
+			invocation=${value}
+			;;
+		workflow_repo)
+			workflow_repo=${value}
+			;;
+		workflow_path)
+			workflow_path=${value}
+			;;
+		workflow_ref)
+			workflow_ref=${value}
+			;;
+		esac
+	done <<<"${parsed}"
+	ci_log "attestation verified for ${image_ref}"
+	if [[ -n "${subject_name}" && -n "${subject_digest}" ]]; then
+		ci_log "  subject    : ${subject_name}@${subject_digest}"
+	fi
+	if [[ -n "${predicate_type}" ]]; then
+		ci_log "  predicate  : ${predicate_type}"
+	fi
+	if [[ -n "${builder_id}" ]]; then
+		ci_log "  builder    : ${builder_id}"
+	fi
+	if [[ -n "${workflow_repo}" || -n "${workflow_path}" || -n "${workflow_ref}" ]]; then
+		local workflow_summary="${workflow_repo}"
+		if [[ -n "${workflow_path}" ]]; then
+			if [[ -n "${workflow_summary}" ]]; then
+				workflow_summary+=" "
+			fi
+			workflow_summary+="${workflow_path}"
+		fi
+		if [[ -n "${workflow_ref}" ]]; then
+			workflow_summary+=" (${workflow_ref})"
+		fi
+		ci_log "  workflow   : ${workflow_summary}"
+	fi
+	if [[ -n "${invocation}" ]]; then
+		ci_log "  run        : ${invocation}"
+>>>>>>> pretty_attestations
 	fi
 	return 0
 }

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -1739,6 +1739,7 @@ def test_ci_verify_dry_run(manage_env):
 
 
 @pytest.mark.ci
+<<<<<<< HEAD
 def test_attestation_verify_outputs_details(manage_env, tmp_path):
     env, _ = manage_env
     fake_bin = tmp_path / "fake_bin"
@@ -1790,6 +1791,66 @@ exit 1
 
 
 @pytest.mark.ci
+||||||| 6c87ec2
+=======
+def test_attestation_verify_outputs_details(manage_env, tmp_path):
+    env, _ = manage_env
+    fake_bin = tmp_path / "fake_bin"
+    fake_bin.mkdir()
+    gh_script = fake_bin / "gh"
+    gh_script.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "attestation" && "${2:-}" == "verify" ]]; then
+  subject=""
+  for arg in "$@"; do
+    case "$arg" in
+      oci://*)
+        subject="${arg#oci://}"
+        ;;
+    esac
+  done
+  if [[ -z "${subject}" ]]; then
+    echo "missing subject" >&2
+    exit 1
+  fi
+  name="${subject%%@*}"
+  name="${name%%:*}"
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    echo "Error: the provided token was denied access to the requested resource, please check the token's expiration and repository access" >&2
+    exit 1
+  fi
+  cat <<JSON
+[{"verificationResult":{"statement":{"predicateType":"https://slsa.dev/provenance/v1","subject":[{"name":"${name}","digest":{"sha256":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}}],"predicate":{"buildDefinition":{"externalParameters":{"workflow":{"path":".github/workflows/publish-docker.yml","ref":"refs/heads/main","repository":"https://github.com/test/repo"}}},"runDetails":{"builder":{"id":"fake-builder"},"metadata":{"invocationId":"https://github.com/test/repo/actions/runs/1"}}}}}}]
+JSON
+  exit 0
+fi
+
+echo "unsupported gh invocation" >&2
+exit 1
+"""
+    )
+    gh_script.chmod(0o755)
+    env_local = env.copy()
+    env_local["PATH"] = f"{str(fake_bin)}:{env_local['PATH']}"
+    env_local["GH_TOKEN"] = "fake-token"
+    env_local["GITHUB_TOKEN"] = "fake-token"
+    result = run_manage(
+        env_local,
+        "attestation-verify",
+        "--env-file",
+        env_local["ENV_FILE"],
+        "--image",
+        "ghcr.io/paudley/core_data/postgres:ci-test",
+    )
+    assert result.returncode == 0
+    assert "attestation verified for" in result.stderr
+    assert "subject    :" in result.stderr
+
+
+@pytest.mark.ci
+>>>>>>> pretty_attestations
 def test_ci_up_dry_run_emits_outputs(manage_env, tmp_path):
     env, _ = manage_env
     ci_env = tmp_path / "ci.env"


### PR DESCRIPTION
This pull request enhances the attestation verification process for CI images by improving error handling, adding automatic credential fallback, and providing more detailed output. The main changes focus on making verification more robust when GitHub tokens lack access, and ensuring users receive clear information about verification results.

**Attestation Verification Improvements**

* The `ci_verify_attestation_for_image` function now automatically retries attestation verification without `GH_TOKEN`/`GITHUB_TOKEN` if access is denied, allowing public attestation checks to pass seamlessly.
* Verification output is now parsed in detail, extracting and logging key provenance information such as subject, predicate type, builder ID, workflow details, and invocation ID.
* Documentation in `README.md` and `CI_USAGE.md` has been updated to explain the new credential fallback behavior and clarify which images are enforced and how third-party dependencies are handled. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R70-R71) [[2]](diffhunk://#diff-4604d17863445fa70bac07bf95851ed23dff74295b00864d76de825aecc0414aR45-R59)

**Testing Enhancements**

* Added a new test `test_attestation_verify_outputs_details` to confirm that attestation verification emits detailed output and handles credential fallback correctly. [[1]](diffhunk://#diff-7e8346b0ea680b9921d653a97988fed4c0d2b24fdb5eba7d9132d2a8e32dd3ddR1742) [[2]](diffhunk://#diff-7e8346b0ea680b9921d653a97988fed4c0d2b24fdb5eba7d9132d2a8e32dd3ddR1794-R1853)