### PR TITLE
fix workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -142,17 +142,17 @@ jobs:
           PG_VERSION: ${{ steps.version.outputs.pg_major || '17' }}
         run: |
           if [ "${{ matrix.service }}" = "postgres" ]; then
-            {
-              echo "args<<'EOT'"
-              echo "CORE_UID=999"
-              echo "CORE_GID=999"
-              echo "CORE_USERNAME=postgres"
-              echo "CORE_GECOS=Core Data PostgreSQL Administrator"
-              echo "CORE_HOME=/home/postgres"
-              echo "PG_VERSION=${PG_VERSION}"
-              echo "AGE_VERSION=master"
-              echo "EOT"
-            } >>"$GITHUB_OUTPUT"
+            cat <<'EOF' >>"$GITHUB_OUTPUT"
+args<<EOT
+CORE_UID=999
+CORE_GID=999
+CORE_USERNAME=postgres
+CORE_GECOS=Core Data PostgreSQL Administrator
+CORE_HOME=/home/postgres
+PG_VERSION=${PG_VERSION}
+AGE_VERSION=master
+EOT
+EOF
           else
             echo "args=" >>"$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
This pull request makes a minor improvement to the script that sets output arguments for the `postgres` service in the `.github/workflows/publish-docker.yml` workflow. The change replaces a sequence of `echo` statements with a single `cat <<EOF` block, making the code more concise and readable.