### PR TITLE
fix worflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -140,19 +140,20 @@ jobs:
         id: build-args
         env:
           PG_VERSION: ${{ steps.version.outputs.pg_major || '17' }}
+        shell: bash
         run: |
-          if [ "${{ matrix.service }}" = "postgres" ]; then
-            cat <<'EOF' >>"$GITHUB_OUTPUT"
-args<<EOT
-CORE_UID=999
-CORE_GID=999
-CORE_USERNAME=postgres
-CORE_GECOS=Core Data PostgreSQL Administrator
-CORE_HOME=/home/postgres
-PG_VERSION=${PG_VERSION}
-AGE_VERSION=master
-EOT
-EOF
+          if [[ "${{ matrix.service }}" == "postgres" ]]; then
+            {
+              echo "args<<EOT"
+              echo "CORE_UID=999"
+              echo "CORE_GID=999"
+              echo "CORE_USERNAME=postgres"
+              echo "CORE_GECOS=Core Data PostgreSQL Administrator"
+              echo "CORE_HOME=/home/postgres"
+              echo "PG_VERSION=${PG_VERSION}"
+              echo "AGE_VERSION=master"
+              echo "EOT"
+            } >>"$GITHUB_OUTPUT"
           else
             echo "args=" >>"$GITHUB_OUTPUT"
           fi
@@ -181,7 +182,6 @@ EOF
             org.opencontainers.image.vendor=${{ github.repository_owner }}
             org.opencontainers.image.source=${{ github.repositoryUrl }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
             org.opencontainers.image.documentation=https://github.com/${{ github.repository }}#published-docker-images
 


### PR DESCRIPTION
This pull request makes minor improvements to the `.github/workflows/publish-docker.yml` workflow for building and publishing Docker images. The main changes focus on standardizing the shell used in a workflow step and refining how build arguments are generated.

Workflow improvements:

* Changed the shell for the build arguments step to explicitly use `bash`, ensuring consistent script behavior.
* Refactored the logic for generating Docker build arguments for the `postgres` service to use Bash conditional syntax and `echo` statements instead of a heredoc, improving readability and reliability.

Metadata adjustments:

* Removed the `org.opencontainers.image.created` label from the Docker image metadata, possibly to streamline the metadata or avoid redundancy.