### PR TITLE
fix: write Erlang cookie to disk for CLI tool authentication

### DIFF
--- a/rabbitmq/entrypoint.sh
+++ b/rabbitmq/entrypoint.sh
@@ -47,6 +47,18 @@ export RABBITMQ_MANAGEMENT_PORT="${RABBITMQ_MANAGEMENT_PORT:-15672}"
 unset RABBITMQ_DEFAULT_PASS_FILE
 unset RABBITMQ_ERLANG_COOKIE_FILE
 
+# Write the cookie to disk so CLI tools (rabbitmqctl, rabbitmq-diagnostics)
+# invoked via "docker compose exec" can authenticate with the broker.
+# The env var is only visible to PID 1; exec'd shells read the file.
+# The file may already exist read-only (0400) from a previous run, so
+# widen permissions before overwriting, then lock back down.
+cookie_file="${RABBITMQ_MNESIA_DIR:-/var/lib/rabbitmq}/.erlang.cookie"
+if [ -f "${cookie_file}" ]; then
+	chmod 600 "${cookie_file}" 2>/dev/null || true
+fi
+printf '%s' "${cookie}" > "${cookie_file}"
+chmod 400 "${cookie_file}"
+
 entrypoint="/opt/rabbitmq/sbin/docker-entrypoint.sh"
 if [ ! -x "${entrypoint}" ]; then
 	entrypoint="$(command -v docker-entrypoint.sh || true)"


### PR DESCRIPTION
## Summary
- Writes the Erlang cookie to `$RABBITMQ_MNESIA_DIR/.erlang.cookie` during container startup so that CLI tools (`rabbitmqctl`, `rabbitmq-diagnostics`) invoked via `docker compose exec` can authenticate with the broker
- Handles pre-existing read-only (0400) cookie files from previous container runs by widening permissions before overwriting
- Locks the cookie file back to 0400 after writing for security

## Context
The RabbitMQ entrypoint exports `RABBITMQ_ERLANG_COOKIE` as an environment variable, but this is only visible to PID 1. When CLI tools are invoked via `docker compose exec`, they spawn a new shell that reads the cookie from `~/.erlang.cookie` on disk. Without this fix, CLI tools fail with "Invalid challenge reply" errors.

## Test plan
- [x] Container starts healthy with all 12 plugins enabled
- [x] `rabbitmq-overview` succeeds (CLI tool authentication works)
- [x] `rabbitmq-plugins -e` lists all enabled plugins
- [x] `rabbitmq-export` exports definitions via management API
- [x] Port connectivity check passes for all 5 listeners (AMQP 5672, Management 15672, Stream 5552, Prometheus 15692, Clustering 25672)
- [x] Consistent hash exchange routes messages correctly (3/3 distribution across 2 queues)
- [x] Stream queue creation and publishing works
- [x] Production config values applied (512MiB memory watermark, channel_max=128, etc.)
- [x] No local alarms reported