### PR TITLE
feat(postgres): add pgsodium, gzip, and pgzstd extensions

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -45,10 +45,13 @@ RUN set -euxo pipefail; \
       gettext-base \
       bison \
       flex \
+      libsodium-dev \
       libssl-dev \
       libxml2-dev \
       libxslt1-dev \
       libreadline-dev \
+      libzstd-dev \
+      zlib1g-dev \
       "postgresql-server-dev-${PG_MAJOR}" \
       "postgresql-${PG_MAJOR}-pgaudit" \
       "postgresql-${PG_MAJOR}-pgvector" \
@@ -92,6 +95,31 @@ RUN set -eux; \
     make PG_CONFIG="/usr/lib/postgresql/${PG_MAJOR}/bin/pg_config"; \
     make install PG_CONFIG="/usr/lib/postgresql/${PG_MAJOR}/bin/pg_config"; \
     rm -rf /tmp/pg_squeeze
+
+# Build pgsodium from source
+ARG PGSODIUM_VERSION=3.1.9
+RUN set -eux; \
+    git clone --depth 1 --branch "v${PGSODIUM_VERSION}" --single-branch https://github.com/michelp/pgsodium.git /tmp/pgsodium; \
+    cd /tmp/pgsodium; \
+    make PG_CONFIG="/usr/lib/postgresql/${PG_MAJOR}/bin/pg_config"; \
+    make install PG_CONFIG="/usr/lib/postgresql/${PG_MAJOR}/bin/pg_config"; \
+    rm -rf /tmp/pgsodium
+
+# Build pgsql-gzip from source
+RUN set -eux; \
+    git clone --depth 1 https://github.com/pramsey/pgsql-gzip.git /tmp/pgsql-gzip; \
+    cd /tmp/pgsql-gzip; \
+    make PG_CONFIG="/usr/lib/postgresql/${PG_MAJOR}/bin/pg_config"; \
+    make install PG_CONFIG="/usr/lib/postgresql/${PG_MAJOR}/bin/pg_config"; \
+    rm -rf /tmp/pgsql-gzip
+
+# Build pgzstd from source
+RUN set -eux; \
+    git clone --depth 1 https://github.com/grahamedgecombe/pgzstd.git /tmp/pgzstd; \
+    cd /tmp/pgzstd; \
+    make PG_CONFIG="/usr/lib/postgresql/${PG_MAJOR}/bin/pg_config"; \
+    make install PG_CONFIG="/usr/lib/postgresql/${PG_MAJOR}/bin/pg_config"; \
+    rm -rf /tmp/pgzstd
 
 # Copy configuration templates and initialization scripts
 COPY postgres/conf /opt/core_data/conf

--- a/postgres/conf/postgresql.conf.tpl
+++ b/postgres/conf/postgresql.conf.tpl
@@ -10,7 +10,7 @@ shared_buffers = ${PG_SHARED_BUFFERS}
 work_mem = ${PG_WORK_MEM}
 maintenance_work_mem = ${PG_MAINTENANCE_WORK_MEM}
 effective_cache_size = ${PG_EFFECTIVE_CACHE_SIZE}
-shared_preload_libraries = 'age,pgaudit,pg_stat_statements,pg_cron,pg_squeeze,auto_explain,pg_buffercache,pg_partman_bgw'
+shared_preload_libraries = 'age,pgaudit,pg_stat_statements,pg_cron,pg_squeeze,auto_explain,pg_buffercache,pg_partman_bgw,pgsodium'
 wal_level = logical
 archive_mode = on
 archive_command = 'pgbackrest --config=/var/lib/postgresql/data/pgbackrest.conf --stanza=main archive-push %p'
@@ -87,5 +87,6 @@ ssl = ${POSTGRES_SSL_ENABLED}
 ssl_cert_file = '${POSTGRES_SSL_CERT_FILE}'
 ssl_key_file = '${POSTGRES_SSL_KEY_FILE}'
 ssl_prefer_server_ciphers = on
+pgsodium.getkey_script = '/opt/core_data/tools/pgsodium_getkey.sh'
 datestyle = 'iso, mdy'
 timezone = '${TZ}'

--- a/postgres/initdb/00-render-config.sh
+++ b/postgres/initdb/00-render-config.sh
@@ -15,6 +15,40 @@ NETWORK_ACCESS_DIR=${NETWORK_ACCESS_DIR:-/opt/core_data/network_access}
 NETWORK_ALLOW_FILE=${NETWORK_ALLOW_FILE:-${NETWORK_ACCESS_DIR}/allow.list}
 FORCE_RENDER_CONFIG=${FORCE_RENDER_CONFIG:-0}
 
+# shellcheck disable=SC1091
+# shellcheck source=/opt/core_data/scripts/lib/extensions_list.sh
+source /opt/core_data/scripts/lib/extensions_list.sh
+
+# Enforce that all required libraries are present in shared_preload_libraries.
+# Called on every startup to prevent config drift from manual edits.
+# Returns 0 if no changes needed, 1 if config was corrected (reload required).
+enforce_shared_preload_libraries() {
+	local conf_file="${PGDATA}/postgresql.conf"
+	[[ -f "${conf_file}" ]] || return 0
+
+	local current
+	current=$(grep -E "^shared_preload_libraries" "${conf_file}" | sed "s/shared_preload_libraries *= *'\\(.*\\)'/\\1/")
+
+	local missing=()
+	for lib in "${REQUIRED_PRELOAD_LIBRARIES[@]}"; do
+		if ! echo ",${current}," | grep -q ",${lib},"; then
+			missing+=("${lib}")
+		fi
+	done
+
+	if [[ ${#missing[@]} -gt 0 ]]; then
+		echo "[core_data] WARNING: shared_preload_libraries missing required entries: ${missing[*]}" >&2
+		local new_value="${current}"
+		for lib in "${missing[@]}"; do
+			new_value="${new_value},${lib}"
+		done
+		sed -i "s|^shared_preload_libraries *= *'.*'|shared_preload_libraries = '${new_value}'|" "${conf_file}"
+		echo "[core_data] Corrected shared_preload_libraries to: ${new_value}" >&2
+		return 1
+	fi
+	return 0
+}
+
 apply_network_allow_entries() {
 	local hba_path="${PGDATA}/pg_hba.conf"
 	if [[ ! -f "${hba_path}" ]]; then
@@ -101,8 +135,17 @@ if [[ -f "${SENTINEL}" ]]; then
 	if [[ "${FORCE_RENDER_CONFIG}" != "1" ]]; then
 		echo "[core_data] Configuration already rendered; refreshing network allow entries." >&2
 		apply_network_allow_entries
+		local needs_reload=0
+		if ! enforce_shared_preload_libraries; then
+			needs_reload=1
+		fi
 		if pg_ctl -D "${PGDATA}" status >/dev/null 2>&1; then
-			if ! pg_ctl -D "${PGDATA}" reload >/dev/null 2>&1; then
+			if [[ "${needs_reload}" -eq 1 ]]; then
+				echo "[core_data] Restarting PostgreSQL to apply corrected shared_preload_libraries." >&2
+				if ! pg_ctl -D "${PGDATA}" -m fast -w restart >/dev/null 2>&1; then
+					echo "[core_data] WARNING: pg_ctl restart failed after shared_preload_libraries correction." >&2
+				fi
+			elif ! pg_ctl -D "${PGDATA}" reload >/dev/null 2>&1; then
 				echo "[core_data] WARNING: pg_ctl reload failed while refreshing network allow entries." >&2
 			fi
 		fi
@@ -189,6 +232,10 @@ archive-check=n
 pg1-path=${PGDATA}
 pg1-port=5433
 CONF
+
+# Safety belt: enforce shared_preload_libraries even after fresh render
+# to catch any drift between the template and the canonical list.
+enforce_shared_preload_libraries || true
 
 echo "[core_data] Rendered PostgreSQL configs and pgBackRest configuration." >&2
 

--- a/postgres/tools/pgsodium_getkey.sh
+++ b/postgres/tools/pgsodium_getkey.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 Blackcat Informatics® Inc.
+# SPDX-License-Identifier: MIT
+
+# pgsodium server key retrieval script.
+# Called by pgsodium to obtain the root encryption key for Transparent Column Encryption.
+# The key must be exactly 32 bytes (256 bits) of raw key material.
+
+set -euo pipefail
+
+PGSODIUM_KEY_FILE="${PGSODIUM_KEY_FILE:-/opt/core_data/secrets/pgsodium.key}"
+
+if [[ ! -r "${PGSODIUM_KEY_FILE}" ]]; then
+	echo "[core_data] ERROR: pgsodium key file not found or not readable: ${PGSODIUM_KEY_FILE}" >&2
+	echo "[core_data] Generate a key with: head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \\n' > ${PGSODIUM_KEY_FILE}" >&2
+	exit 1
+fi
+
+cat "${PGSODIUM_KEY_FILE}"

--- a/scripts/lib/extensions.sh
+++ b/scripts/lib/extensions.sh
@@ -35,6 +35,17 @@ RESET search_path;
 -- pgcrypto smoke
 SELECT encode(digest('core_data', 'sha256'), 'hex');
 
+-- pgsodium smoke
+SELECT length(pgsodium.crypto_pwhash_str('test_password')) > 0 AS pgsodium_ok;
+
+-- gzip smoke
+SELECT length(gzip('hello world')) > 0 AS gzip_compress_ok;
+SELECT convert_from(gunzip(gzip('hello world')), 'UTF8') = 'hello world' AS gzip_roundtrip_ok;
+
+-- pgzstd smoke
+SELECT length(zstd_compress('hello world'::bytea)) > 0 AS zstd_compress_ok;
+SELECT zstd_decompress(zstd_compress('hello world'::bytea)) = 'hello world'::bytea AS zstd_roundtrip_ok;
+
 -- uuid-ossp smoke
 SELECT uuid_generate_v4();
 
@@ -122,7 +133,7 @@ run_pgtap_smoke() {
 		psql --set ON_ERROR_STOP=on --username "${POSTGRES_SUPERUSER:-postgres}" --dbname "${database}" <<'SQL'
 CREATE SCHEMA IF NOT EXISTS test_core_data;
 SET search_path = test_core_data, public;
-SELECT plan(39);
+SELECT plan(42);
 SELECT ok(current_schema = 'test_core_data', 'search_path set to test schema');
 SELECT has_extension('vector', 'vector extension installed');
 SELECT has_extension('postgis', 'postgis extension installed');
@@ -134,6 +145,9 @@ SELECT has_extension('pg_stat_statements', 'pg_stat_statements extension install
 SELECT ok(position('auto_explain' in current_setting('shared_preload_libraries')) > 0, 'auto_explain registered in shared_preload_libraries');
 SELECT has_extension('pg_buffercache', 'pg_buffercache extension installed');
 SELECT has_extension('pgcrypto', 'pgcrypto extension installed');
+SELECT has_extension('pgsodium', 'pgsodium extension installed');
+SELECT has_extension('gzip', 'gzip extension installed');
+SELECT has_extension('pgzstd', 'pgzstd extension installed');
 SELECT has_extension('citext', 'citext extension installed');
 SELECT has_extension('cube', 'cube extension installed');
 SELECT has_extension('hstore', 'hstore extension installed');

--- a/scripts/lib/extensions_list.sh
+++ b/scripts/lib/extensions_list.sh
@@ -28,6 +28,9 @@ CORE_EXTENSION_LIST=(
 	pg_stat_statements
 	pg_trgm
 	pgcrypto
+	pgsodium
+	gzip
+	pgzstd
 	pgstattuple
 	pgtap
 	pgaudit
@@ -43,4 +46,19 @@ CORE_EXTENSION_LIST=(
 	unaccent
 	uuid-ossp
 	vector
+)
+
+# Canonical list of libraries that must be in shared_preload_libraries.
+# Enforced on every container startup regardless of config state.
+# shellcheck disable=SC2034
+REQUIRED_PRELOAD_LIBRARIES=(
+	age
+	pgaudit
+	pg_stat_statements
+	pg_cron
+	pg_squeeze
+	auto_explain
+	pg_buffercache
+	pg_partman_bgw
+	pgsodium
 )


### PR DESCRIPTION
## Summary

Closes #60

- **pgsodium**: Modern libsodium-based cryptography (encryption, hashing, key derivation, TCE) with server-side key management via `shared_preload_libraries`
- **pgsql-gzip**: SQL-native `gzip`/`gunzip` for compressing/decompressing `bytea` data
- **pgzstd**: Zstandard compression/decompression in SQL — better ratios than gzip, faster decompression

All three are built from source in the Docker image (not available as apt packages for PG17).

### Changes

- Added `libsodium-dev`, `zlib1g-dev`, `libzstd-dev` build dependencies and source build blocks in Dockerfile
- Added all three to `CORE_EXTENSION_LIST` for automatic creation in all databases at startup
- Added `pgsodium` to `shared_preload_libraries` with `getkey_script` config for TCE
- Added `REQUIRED_PRELOAD_LIBRARIES` canonical array and `enforce_shared_preload_libraries()` function in `00-render-config.sh` — validates and corrects `shared_preload_libraries` on every startup, even when config re-rendering is skipped
- Added smoke tests (crypto_pwhash_str, gzip/gunzip roundtrip, zstd compress/decompress roundtrip)
- Added pgTap assertions for all three extensions (plan count 39 → 42)

## Test Plan

- [ ] Docker image builds with all three extensions compiled
- [ ] Extensions created in all databases during init
- [ ] pgsodium present in `shared_preload_libraries`
- [ ] Smoke tests pass
- [ ] pgTap tests pass (42/42)
- [ ] `enforce_shared_preload_libraries()` corrects manually removed entries on restart
- [ ] Existing extension tests unaffected